### PR TITLE
Allow server status to be called wihtout a wallet

### DIFF
--- a/app/acapy.js
+++ b/app/acapy.js
@@ -57,6 +57,23 @@ const getSubWalletToken = async (subWalletName) => {
   return token
 }
 
+const serverStatusCall = async ({ query }) => {
+  const fetch = (await import('node-fetch')).default
+
+  const url = new URL(`${ACAPY_ADMIN_SERVICE}/status`)
+  const search = new URLSearchParams(query)
+  url.search = search.toString()
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'x-api-key': ACAPY_API_KEY,
+    },
+  })
+
+  return response
+}
+
 const noBodyMethods = new Set(['GET', 'HEAD'])
 const subWalletCall = async (token, { path, query, method, body }) => {
   const fetch = (await import('node-fetch')).default
@@ -82,5 +99,6 @@ module.exports = {
   querySubWallets,
   createSubWallet,
   getSubWalletToken,
+  serverStatusCall,
   subWalletCall,
 }

--- a/helm/veritable-acapy-proxy/Chart.yaml
+++ b/helm/veritable-acapy-proxy/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: veritable-acapy-proxy
-appVersion: '1.0.0'
+appVersion: '1.1.0'
 description: A Helm chart for veritable-acapy-proxy
-version: '1.0.0'
+version: '1.1.0'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/veritable-acapy-proxy/values.yaml
+++ b/helm/veritable-acapy-proxy/values.yaml
@@ -10,5 +10,5 @@ config:
 image:
   repository: ghcr.io/digicatapult/veritable-acapy-proxy
   pullPolicy: IfNotPresent
-  tag: 'v1.0.0'
+  tag: 'v1.1.0'
   pullSecrets: ['ghcr-digicatapult']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/veritable-acapy-proxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/veritable-acapy-proxy",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",
@@ -4003,9 +4003,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mocha": {
@@ -9886,9 +9886,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mocha": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-acapy-proxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Proxy service for AcaPy cloud wallets",
   "main": "app/index.js",
   "scripts": {

--- a/test/helper/routeHelper.js
+++ b/test/helper/routeHelper.js
@@ -93,6 +93,37 @@ async function listDidsUnauthorized({ app }, query = {}) {
     })
 }
 
+async function serverStatus({ app, token }, query = {}) {
+  return request(app)
+    .get(`/${API_MAJOR_VERSION}/aca-py/status`)
+    .query(query)
+    .set('Accept', 'application/json, text/plain')
+    .set('Authorization', `Bearer ${token}`)
+    .send()
+    .then((response) => {
+      return response
+    })
+    .catch((err) => {
+      console.error(`healthCheckErr ${err}`)
+      return err
+    })
+}
+
+async function serverStatusUnauthorized({ app }, query = {}) {
+  return request(app)
+    .get(`/${API_MAJOR_VERSION}/aca-py/status`)
+    .query(query)
+    .set('Accept', 'application/json, text/plain')
+    .send()
+    .then((response) => {
+      return response
+    })
+    .catch((err) => {
+      console.error(`healthCheckErr ${err}`)
+      return err
+    })
+}
+
 async function createDid({ app, token }, body) {
   return request(app)
     .post(`/${API_MAJOR_VERSION}/aca-py/wallet/did/create`)
@@ -113,7 +144,9 @@ module.exports = {
   healthCheck,
   createWalletUnauthorized,
   createWallet,
-  listDidsUnauthorized,
   listDids,
+  listDidsUnauthorized,
+  serverStatus,
+  serverStatusUnauthorized,
   createDid,
 }

--- a/test/integration/createWallet.test.js
+++ b/test/integration/createWallet.test.js
@@ -76,7 +76,7 @@ describe('wallet creation', function () {
     withAuthToken(context)
     withExistingWallet(context)
 
-    it('should create a new wallet', async function () {
+    it('should not create a new wallet', async function () {
       const response = await createWallet(context, {
         label: 'test',
         wallet_key: 'MySecretKey123',

--- a/test/integration/serverStatusGet.test.js
+++ b/test/integration/serverStatusGet.test.js
@@ -1,0 +1,34 @@
+const { describe, it } = require('mocha')
+const { expect } = require('chai')
+
+const { createHttpServer } = require('../../app/server')
+const { serverStatus, serverStatusUnauthorized } = require('../helper/routeHelper')
+const { withAuthToken } = require('../helper/auth0')
+
+describe('server status', function () {
+  describe('unauthenticated', function () {
+    const context = {}
+    before(async function () {
+      context.app = (await createHttpServer()).app
+    })
+
+    it('should fail with 401', async function () {
+      const response = await serverStatusUnauthorized(context)
+      expect(response.status).to.equal(401)
+    })
+  })
+
+  describe('server status without a wallet', function () {
+    const context = {}
+    before(async function () {
+      context.app = (await createHttpServer()).app
+    })
+    withAuthToken(context)
+
+    it('should succeed and return server status', async function () {
+      const response = await serverStatus(context)
+      expect(response.status).to.equal(200)
+      expect(response.body.version).to.be.a('String')
+    })
+  })
+})


### PR DESCRIPTION
 Allow server status to be called without a wallet. Also fix a bug where headers are sent twice on a wallet create conlict